### PR TITLE
SOCINT-245 changed CCUI port to 5001

### DIFF
--- a/scripts/envCheck.sh
+++ b/scripts/envCheck.sh
@@ -11,7 +11,7 @@ mock_services_port="8162"
 pubsub_emulator_port="9808"
 redis_port="6379"
 cc_service_port="8171"
-ccui_port="5000"
+ccui_port="5001"
 
 error_found=0
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -19,7 +19,7 @@ logging:
     '[org.openqa.selenium.remote.ProtocolHandshake]': WARN
 
 ccui:
-  baseurl: http://localhost:5000/
+  baseurl: http://localhost:5001/
   
 webdriver:
   type: FIREFOX


### PR DESCRIPTION

When running locally, expect CCUI to run on port 5001 rather than 5000 which can conflict with RHUI expectations.

JIRA LINK: https://collaborate2.ons.gov.uk/jira/browse/SOCINT-245